### PR TITLE
Update `asset-meta-data` to include params for new synthetic assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Includes:
 ; (2) Sign the order data with the Starkware private key
 (def signed-order
   (let [stark-priv (biginteger 0x10df7f0ca8e3c1e1bd56693bb2725342c3fe08d7042ee6a4d2dad592b9a90c3)]
-    (dydx/sign-order stark-priv order (dydx/asset-meta-data false))))
+    (dydx/sign-order stark-priv order dydx/asset-meta-data)))
 
 
 ; (3) Sign the request data second time with the dYdX api credentials
@@ -49,21 +49,19 @@ Includes:
     creds))
 
 ; Done -- you now have a signed RING request
-{:method       :post,
- :url          "https://api.dydx.exchange/v3/orders",
- :accept       "application/json",
- :content-type "application/json",
- :body         "{\"clientId\":\"91364379829165\",\"limitFee\":\"0.015\",\"expiration\":\"2022-12-21T21:30:20.200Z\",\"signature\":\"02c23b2b028e53251e615eb1a686e8b3e1ce735b7e0fa3fdf0b45772eb9d1bf9061a7881b83f6a6c26fa9810a9b17f91756f829956e193e04217626e88b34e4e\",\"postOnly\":false,\"type\":\"LIMIT\",\"size\":\"100\",\"side\":\"SELL\",\"market\":\"BTC-USD\",\"timeInForce\":\"GTT\",\"price\":\"18000\"}",
- :headers      {"User-Agent"      "sixtant/dydx-starkware",
-                "DYDX-SIGNATURE"  "6nDdDFAfBi2x4BsfRolT-1631f1zXCdar3-o1ifMk6s=",
-                "DYDX-API-KEY"    "11f3726d-72c9-f3c7-eed9-980655c369d6",
-                "DYDX-TIMESTAMP"  "2021-05-02T19:58:03.591Z",
+{:method       :post
+ :url          "https://api.dydx.exchange/v3/orders"
+ :accept       "application/json"
+ :content-type "application/json"
+ :body         "{\"clientId\":\"91364379829165\",\"limitFee\":\"0.015\",\"expiration\":\"2022-12-21T21:30:20.200Z\",\"signature\":\"02c23b2b028e53251e615eb1a686e8b3e1ce735b7e0fa3fdf0b45772eb9d1bf9061a7881b83f6a6c26fa9810a9b17f91756f829956e193e04217626e88b34e4e\",\"postOnly\":false,\"type\":\"LIMIT\",\"size\":\"100\",\"side\":\"SELL\",\"market\":\"BTC-USD\",\"timeInForce\":\"GTT\",\"price\":\"18000\"}"
+ :headers      {"User-Agent"      "sixtant/dydx-starkware"
+                "DYDX-SIGNATURE"  "6nDdDFAfBi2x4BsfRolT-1631f1zXCdar3-o1ifMk6s="
+                "DYDX-API-KEY"    "11f3726d-72c9-f3c7-eed9-980655c369d6"
+                "DYDX-TIMESTAMP"  "2021-05-02T19:58:03.591Z"
                 "DYDX-PASSPHRASE" "TvsLWDMQGA2-9MXwxV-e"}}
 ```
 
 ## License
-
-Copyright © 2021 FIXME
 
 This program and the accompanying materials are made available under the
 terms of the Eclipse Public License 2.0 which is available at

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dydx-starkware "0.1.0"
+(defproject dydx-starkware "0.2.0"
   :description "Creation, hashing, and signing of orders with Starkware's L2 as used by dYdX."
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}

--- a/src/io/sixtant/dydx_starkware.clj
+++ b/src/io/sixtant/dydx_starkware.clj
@@ -42,45 +42,114 @@
 
 ;; For now this data is hardcoded, though we're hoping they'll add it to the
 ;; API.
-(defn asset-meta-data
-  "Metadata about assets tradeable on dYdX which is necessary to sign orders."
-  [testnet?]
+(def asset-meta-data
+  "Parameters which are necessary to construct / sign the starkware orders."
   {:collateral-asset "USDC"
    :>synthetic-asset {"BTC-USD"   "BTC"
                       "ETH-USD"   "ETH"
                       "LINK-USD"  "LINK"
+
                       "AAVE-USD"  "AAVE"
                       "UNI-USD"   "UNI"
                       "SUSHI-USD" "SUSHI"
                       "SOL-USD"   "SOL"
                       "YFI-USD"   "YFI"
-                      "1INCH-USD" "1INCH"}
+                      "1INCH-USD" "1INCH"
+
+                      "AVAX-USD"  "AVAX"
+                      "SNX-USD"   "SNX"
+                      "CRV-USD"   "CRV"
+                      "UMA-USD"   "UMA"
+                      "DOT-USD"   "DOT"
+                      "DOGE-USD"  "DOGE"
+
+                      "MATIC-USD" "MATIC"
+                      "MKR-USD"   "MKR"
+                      "FIL-USD"   "FIL"
+                      "ADA-USD"   "ADA"
+                      "ATOM-USD"  "ATOM"
+                      "COMP-USD"  "COMP"
+                      "BCH-USD"   "BCH"
+                      "LTC-USD"   "LTC"
+                      "EOS-USD"   "EOS"
+                      "ALGO-USD"  "ALGO"
+                      "ZRX-USD"   "ZRX"
+                      "XMR-USD"   "XMR"
+                      "ZEC-USD"   "ZEC"}
    :>asset-id        (enc/map-vals
                        biginteger
-                       {"USDC"  (if testnet?
-                                  0x02c04d8b650f44092278a7cb1e1028c82025dff622db96c934b611b84cc8de5a
-                                  0x02893294412a4c8f915f75892b395ebbf6859ec246ec365c3b1f56f47c3a0a5d)
+                       {"USDC"  0x02893294412a4c8f915f75892b395ebbf6859ec246ec365c3b1f56f47c3a0a5d
                         "BTC"   0x4254432d3130000000000000000000
                         "ETH"   0x4554482d3900000000000000000000
                         "LINK"  0x4c494e4b2d37000000000000000000
+
                         "AAVE"  0x414156452d38000000000000000000
                         "UNI"   0x554e492d3700000000000000000000
                         "SUSHI" 0x53555348492d370000000000000000
                         "SOL"   0x534f4c2d3700000000000000000000
                         "YFI"   0x5946492d3130000000000000000000
-                        "1INCH" 0x31494e43482d370000000000000000})
+                        "1INCH" 0x31494e43482d370000000000000000
+
+                        "AVAX"  0x415641582d37000000000000000000
+                        "SNX"   0x534e582d3700000000000000000000
+                        "CRV"   0x4352562d3600000000000000000000
+                        "UMA"   0x554d412d3700000000000000000000
+                        "DOT"   0x444f542d3700000000000000000000
+                        "DOGE"  0x444f47452d35000000000000000000
+
+                        "MATIC" 0x4d415449432d360000000000000000
+                        "MKR"   0x4d4b522d3900000000000000000000
+                        "FIL"   0x46494c2d3700000000000000000000
+                        "ADA"   0x4144412d3600000000000000000000
+                        "ATOM"  0x41544f4d2d37000000000000000000
+                        "COMP"  0x434f4d502d38000000000000000000
+                        "BCH"   0x4243482d3800000000000000000000
+                        "LTC"   0x4c54432d3800000000000000000000
+                        "EOS"   0x454f532d3600000000000000000000
+                        "ALGO"  0x414c474f2d36000000000000000000
+                        "ZRX"   0x5a52582d3600000000000000000000
+                        "XMR"   0x584d522d3800000000000000000000
+                        "ZEC"   0x5a45432d3800000000000000000000})
    :>lots            (enc/map-vals
                        biginteger
                        {"USDC"  1e6M
                         "BTC"   1e10M
                         "ETH"   1e9M
                         "LINK"  1e7M
+
                         "AAVE"  1e8M
                         "UNI"   1e7M
                         "SUSHI" 1e7M
                         "SOL"   1e7M
                         "YFI"   1e10M
-                        "1INCH" 1e7M})})
+                        "1INCH" 1e7M
+
+                        "AVAX"  1e7M
+                        "SNX"   1e7M
+                        "CRV"   1e6M
+                        "UMA"   1e7M
+                        "DOT"   1e7M
+                        "DOGE"  1e5M
+
+                        "MATIC" 1e6M
+                        "MKR"   1e9M
+                        "FIL"   1e7M
+                        "ADA"   1e6M
+                        "ATOM"  1e7M
+                        "COMP"  1e8M
+                        "BCH"   1e8M
+                        "LTC"   1e8M
+                        "EOS"   1e6M
+                        "ALGO"  1e6M
+                        "ZRX"   1e6M
+                        "XMR"   1e8M
+                        "ZEC"   1e8M})})
+
+
+(def asset-meta-data-testnet
+  "Same as `asset-meta-data`, except with dYdX's testnet USDC contract."
+  (let [addr 0x02c04d8b650f44092278a7cb1e1028c82025dff622db96c934b611b84cc8de5a]
+    (assoc-in asset-meta-data [:>asset-id "USDC"] (biginteger addr))))
 
 
 (defn bytes->urlb64 [^bytes b] (String. (.encode (Base64/getUrlEncoder) b)))
@@ -140,7 +209,7 @@
   ; (2) Sign the order data with the Starkware private key
   (def signed-order
     (let [stark-priv (biginteger 0x10df7f0ca8e3c1e1bd56693bb2725342c3fe08d7042ee6a4d2dad592b9a90c3)]
-      (dydx/sign-order stark-priv order (dydx/asset-meta-data false))))
+      (dydx/sign-order stark-priv order dydx/asset-meta-data)))
 
 
   ; (3) Sign the request data second time with the dYdX api credentials
@@ -157,13 +226,13 @@
       creds))
 
   ; Done -- you now have a signed RING request
-  {:method       :post,
-   :url          "https://api.dydx.exchange/v3/orders",
-   :accept       "application/json",
-   :content-type "application/json",
-   :body         "{\"clientId\":\"91364379829165\",\"limitFee\":\"0.015\",\"expiration\":\"2022-12-21T21:30:20.200Z\",\"signature\":\"02c23b2b028e53251e615eb1a686e8b3e1ce735b7e0fa3fdf0b45772eb9d1bf9061a7881b83f6a6c26fa9810a9b17f91756f829956e193e04217626e88b34e4e\",\"postOnly\":false,\"type\":\"LIMIT\",\"size\":\"100\",\"side\":\"SELL\",\"market\":\"BTC-USD\",\"timeInForce\":\"GTT\",\"price\":\"18000\"}",
-   :headers      {"User-Agent"      "sixtant/dydx-starkware",
-                  "DYDX-SIGNATURE"  "6nDdDFAfBi2x4BsfRolT-1631f1zXCdar3-o1ifMk6s=",
-                  "DYDX-API-KEY"    "11f3726d-72c9-f3c7-eed9-980655c369d6",
-                  "DYDX-TIMESTAMP"  "2021-05-02T19:58:03.591Z",
+  {:method       :post
+   :url          "https://api.dydx.exchange/v3/orders"
+   :accept       "application/json"
+   :content-type "application/json"
+   :body         "{\"clientId\":\"91364379829165\",\"limitFee\":\"0.015\",\"expiration\":\"2022-12-21T21:30:20.200Z\",\"signature\":\"02c23b2b028e53251e615eb1a686e8b3e1ce735b7e0fa3fdf0b45772eb9d1bf9061a7881b83f6a6c26fa9810a9b17f91756f829956e193e04217626e88b34e4e\",\"postOnly\":false,\"type\":\"LIMIT\",\"size\":\"100\",\"side\":\"SELL\",\"market\":\"BTC-USD\",\"timeInForce\":\"GTT\",\"price\":\"18000\"}"
+   :headers      {"User-Agent"      "sixtant/dydx-starkware"
+                  "DYDX-SIGNATURE"  "6nDdDFAfBi2x4BsfRolT-1631f1zXCdar3-o1ifMk6s="
+                  "DYDX-API-KEY"    "11f3726d-72c9-f3c7-eed9-980655c369d6"
+                  "DYDX-TIMESTAMP"  "2021-05-02T19:58:03.591Z"
                   "DYDX-PASSPHRASE" "TvsLWDMQGA2-9MXwxV-e"}})

--- a/test/io/sixtant/dydx_starkware_test.clj
+++ b/test/io/sixtant/dydx_starkware_test.clj
@@ -54,7 +54,7 @@
 
 (deftest sign-order-test
   (testing "dydx order signature"
-    (let [amd (asset-meta-data true)
+    (let [amd asset-meta-data-testnet
           signed (sign-order mock-start-privkey mock-order-request amd)]
       (is (= (:signature signed) (:signature mock-signed-request))
           "signature matches the one produced by dydx3-python")


### PR DESCRIPTION
This PR adds signature functionality for the newer perpetuals markets, whose constants I transcribed from https://github.com/dydxprotocol/dydx-v3-python/blob/master/dydx3/constants.py.  